### PR TITLE
Update GitHub Actions workflow to correct Javadocs path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          mv target/site $HOME/javadocs
+          mv target/site/jacoco $HOME/javadocs
           cd $HOME
           git clone --depth 1 --branch gh-pages git@github.com:Coho04/GithubAPI.git gh-pages
           cd gh-pages


### PR DESCRIPTION
The path used for moving Javadocs in the Pages workflow was incorrect. This commit changes the path from `target/site` to `target/site/jacoco` to ensure the Javadocs are moved to the right directory.

---
name: Pull Request
about: Propose changes to the codebase
title: ''
labels: ''
assignees: ''

---

## Description

Please provide a brief description of your changes.

## Changes

- List of changes
- ...

## Verification

- [ ] Changes have been tested locally.
- [ ] Documentation has been updated accordingly.

## Related Issues

Fixes # (issue number)

## Additional Information

Add any other information here.